### PR TITLE
add hyphen to mention pattern

### DIFF
--- a/lib/mentionable.rb
+++ b/lib/mentionable.rb
@@ -3,7 +3,7 @@
 require 'mentionable/version'
 
 module Mentionable
-  REGEXP = /@\w+/.freeze
+  REGEXP = /@[\w-]+/.freeze
 
   def self.included(base)
     base.after_save do


### PR DESCRIPTION
[fjordllc/bootcamp](https://github.com/fjordllc/bootcamp)の[\`\-\` がついているユーザーにメンション通知がいかない ](https://github.com/fjordllc/bootcamp/issues/2498)のバグを修正するためのPull Requestです。

 `@hituzi-no-sippo` を入力した際、 `@hituzi-no-sippo` をメンションと認識されるようにしました。今までは、 `-` の前まで、 `@hituzi` までしかメンションと認識されませんでした。
